### PR TITLE
Expand recent posts window to 6 months

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,4 +7,4 @@ Stable tag: 1.0.0
 License: GPLv2 or later
 
 == Description ==
-Plugin para gerar um jornal em HTML a partir das notícias publicadas nos últimos 60 dias.
+Plugin para gerar um jornal em HTML a partir das notícias publicadas nos últimos 6 meses.

--- a/wp-jornal.php
+++ b/wp-jornal.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Jornal
- * Description: Gera um jornal em HTML a partir das notícias dos últimos 60 dias.
+ * Description: Gera um jornal em HTML a partir das notícias dos últimos 6 meses.
  * Version: 1.0.0
  * Author: Seu Nome
  */
@@ -109,13 +109,13 @@ function wpj_admin_page()
 }
 
 /**
- * Busca posts dos últimos 60 dias
+ * Busca posts dos últimos 6 meses
  */
 function wpj_recent_posts($exclude = 0)
 {
     $args = [
         'date_query' => [
-            'after' => date('Y-m-d', strtotime('-60 days')),
+            'after' => date('Y-m-d', strtotime('-6 months')),
         ],
         'posts_per_page' => -1,
         'post_status' => 'publish',


### PR DESCRIPTION
## Summary
- widen plugin timeframe to include posts from the past 6 months
- update descriptions to reference the new 6 month window

## Testing
- `php -l wp-jornal.php`


------
https://chatgpt.com/codex/tasks/task_e_688b9827df3c832c971d038edb58dd40