### PR TITLE
Expandir busca para 18 meses

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,4 +7,4 @@ Stable tag: 1.0.0
 License: GPLv2 or later
 
 == Description ==
-Plugin para gerar um jornal em HTML a partir das notícias publicadas nos últimos 6 meses.
+Plugin para gerar um jornal em HTML a partir das notícias publicadas nos últimos 18 meses.

--- a/wp-jornal.php
+++ b/wp-jornal.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Jornal
- * Description: Gera um jornal em HTML a partir das notícias dos últimos 6 meses.
+ * Description: Gera um jornal em HTML a partir das notícias dos últimos 18 meses.
  * Version: 1.0.0
  * Author: Seu Nome
  */
@@ -111,13 +111,13 @@ function wpj_admin_page()
 }
 
 /**
- * Busca posts dos últimos 6 meses
+ * Busca posts dos últimos 18 meses
  */
 function wpj_recent_posts($exclude = 0)
 {
     $args = [
         'date_query' => [
-            'after' => date('Y-m-d', strtotime('-6 months')),
+            'after' => date('Y-m-d', strtotime('-18 months')),
         ],
         'posts_per_page' => -1,
         'post_status' => 'publish',


### PR DESCRIPTION
## Summary
- aumentar intervalo dos posts para os últimos 18 meses
- atualizar descrições do plugin para refletir novo intervalo

## Testing
- `php -l wp-jornal.php`


------
https://chatgpt.com/codex/tasks/task_e_688b99a1b890832cb4b625e05c2f0920