### PR TITLE
Refactor article generation to clean Divi markup and split content

### DIFF
--- a/modelo/materia-full.html
+++ b/modelo/materia-full.html
@@ -6,15 +6,15 @@
     <div class="columns">
 
         <div>
-            <p>__post_1_conteudo_paragrafo__</p>
+            <p>__post_1_conteudo_paragrafo_a__</p>
         </div>
 
         <div>
-            <p>__post_1_conteudo_paragrafo__</p>
+            <p>__post_1_conteudo_paragrafo_b__</p>
         </div>
 
         <div>
-            <p>__post_1_conteudo_paragrafo__</p>
+            <p>__post_1_conteudo_paragrafo_c__</p>
         </div>
 
 

--- a/modelo/materia.html
+++ b/modelo/materia.html
@@ -21,15 +21,15 @@
     <div class="columns">
 
         <div>
-            <p>__post_1_conteudo_paragrafo__</p>
+            <p>__post_1_conteudo_paragrafo_a__</p>
         </div>
 
         <div>
-            <p>__post_1_conteudo_paragrafo__</p>
+            <p>__post_1_conteudo_paragrafo_b__</p>
         </div>
 
         <div>
-            <p>__post_1_conteudo_paragrafo__</p>
+            <p>__post_1_conteudo_paragrafo_c__</p>
         </div>
 
 

--- a/wp-jornal.php
+++ b/wp-jornal.php
@@ -172,13 +172,72 @@ function wpj_list_jornais()
 }
 
 /**
- * Limita caracteres e adiciona reticências
+ * Remove shortcodes do Divi e tags HTML.
+ */
+function wpj_clean_text($text)
+{
+    $text = strip_shortcodes($text);
+    $text = wp_strip_all_tags($text);
+    $text = preg_replace('/\s+/u', ' ', $text);
+    return trim($text);
+}
+
+/**
+ * Corta o texto sem quebrar palavras.
+ * Retorna um array com a parte inicial e o restante.
+ */
+function wpj_cut_text($text, $limit)
+{
+    if (mb_strlen($text) <= $limit) {
+        return [$text, ''];
+    }
+    $cut = mb_substr($text, 0, $limit);
+    $last_space = mb_strrpos($cut, ' ');
+    if ($last_space !== false) {
+        $head = mb_substr($cut, 0, $last_space);
+        $tail = ltrim(mb_substr($text, $last_space));
+    } else {
+        $head = $cut;
+        $tail = ltrim(mb_substr($text, $limit));
+    }
+    return [$head, $tail];
+}
+
+/**
+ * Divide o texto em partes iguais sem quebrar palavras.
+ */
+function wpj_split_equal_parts($text, $parts)
+{
+    $segments = [];
+    $len = mb_strlen($text);
+    $start = 0;
+    for ($i = $parts; $i > 1; $i--) {
+        $avg = (int) ceil(($len - $start) / $i);
+        $offset = $start + $avg;
+        if ($offset < $len) {
+            $next_space = mb_strpos($text, ' ', $offset);
+            if ($next_space === false) {
+                $next_space = $len;
+            }
+        } else {
+            $next_space = $len;
+        }
+        $segments[] = trim(mb_substr($text, $start, $next_space - $start));
+        $start = $next_space + 1;
+    }
+    $segments[] = trim(mb_substr($text, $start));
+    return $segments;
+}
+
+/**
+ * Limita caracteres e adiciona reticências sem quebrar palavras.
  */
 function wpj_limit_chars($text, $limit)
 {
-    $text = wp_strip_all_tags($text);
+    $text = wpj_clean_text($text);
     if (mb_strlen($text) > $limit) {
-        return mb_substr($text, 0, $limit - 3) . '...';
+        list($short, $rest) = wpj_cut_text($text, $limit);
+        return $short . '...';
     }
     return $text;
 }
@@ -191,6 +250,7 @@ function wpj_generate_jornal($destaque_id, $posts_ids, $contra)
     $template_dir = WP_JORNAL_DIR . 'modelo/';
     $capa_tpl = file_get_contents($template_dir . 'capa.html');
     $materia_tpl = file_get_contents($template_dir . 'materia.html');
+    $materia_full_tpl = file_get_contents($template_dir . 'materia-full.html');
     $contracapa_tpl = file_get_contents($template_dir . 'contracapa.html');
     $html_tpl = file_get_contents($template_dir . 'html-completo.html');
 
@@ -233,23 +293,58 @@ function wpj_generate_jornal($destaque_id, $posts_ids, $contra)
     foreach ($all_posts as $post_id) {
         $p = get_post($post_id);
         $img = wpj_post_image($post_id);
-        $temp = $materia_tpl;
+
+        $author = get_the_author_meta('display_name', $p->post_author);
+        $texto = wpj_clean_text($p->post_content);
+        $texto .= ' <small><strong>Autor:</strong> ' . esc_html($author) . ' </small>';
+
+        list($parte1, $resto) = wpj_cut_text($texto, 700);
+        $paginas = [];
+        if (mb_strlen($resto) <= 4900) {
+            $paginas[] = wpj_split_equal_parts($resto, 3);
+        } else {
+            list($primeira, $resto_total) = wpj_cut_text($resto, 4900);
+            $paginas[] = wpj_split_equal_parts($primeira, 3);
+            while ($resto_total !== '') {
+                list($chunk, $resto_total) = wpj_cut_text($resto_total, 6700);
+                $paginas[] = wpj_split_equal_parts($chunk, 3);
+            }
+        }
+
+        $primeira_pagina = array_shift($paginas);
         $temp = str_replace([
             '__post_1_titulo__',
             '__post_1_data__',
             '__post_1_conteudo_700__',
-            '__post_1_conteudo_paragrafo__',
+            '__post_1_conteudo_paragrafo_a__',
+            '__post_1_conteudo_paragrafo_b__',
+            '__post_1_conteudo_paragrafo_c__',
             '__post_1_imagem_url__',
             '__post_1_imagem_legenda__'
         ], [
             esc_html($p->post_title),
             get_the_date('d/m/Y', $p),
-            wpj_limit_chars($p->post_content, 700),
-            apply_filters('the_content', $p->post_content),
+            $parte1,
+            $primeira_pagina[0] ?? '',
+            $primeira_pagina[1] ?? '',
+            $primeira_pagina[2] ?? '',
             esc_url($img['url']),
             esc_html($img['caption'])
-        ], $temp);
+        ], $materia_tpl);
         $materias_html .= $temp;
+
+        foreach ($paginas as $pagina) {
+            $temp_full = str_replace([
+                '__post_1_conteudo_paragrafo_a__',
+                '__post_1_conteudo_paragrafo_b__',
+                '__post_1_conteudo_paragrafo_c__'
+            ], [
+                $pagina[0] ?? '',
+                $pagina[1] ?? '',
+                $pagina[2] ?? ''
+            ], $materia_full_tpl);
+            $materias_html .= $temp_full;
+        }
     }
 
     // Contracapa


### PR DESCRIPTION
## Summary
- Clean Divi shortcodes and HTML before generating excerpts
- Split article content into 700-char lead and column segments with optional extra pages
- Update templates to use separate placeholders for each column

## Testing
- `php -l wp-jornal.php`


------
https://chatgpt.com/codex/tasks/task_e_688b9f357774832cb0dc89098d2d2a78