### PR TITLE
Increase front page summary length and image height

### DIFF
--- a/modelo/html-completo.html
+++ b/modelo/html-completo.html
@@ -47,6 +47,9 @@
             width: 100%;
             height: 250px;
         }
+        #pagina-1 .columns.with-image .image-placeholder {
+            height: 700px;
+        }
         .columns .text, .columns > div {
             flex: 1;
         }

--- a/wp-jornal.php
+++ b/wp-jornal.php
@@ -266,7 +266,7 @@ function wpj_generate_jornal($destaque_id, $posts_ids, $contra)
     ], [
         esc_html($destaque->post_title),
         get_the_date('d/m/Y', $destaque),
-        wpj_limit_chars($destaque->post_content, 700),
+        wpj_limit_chars($destaque->post_content, 1800),
         esc_url($destaque_img['url']),
         esc_html($destaque_img['caption'])
     ], $capa_tpl);


### PR DESCRIPTION
## Summary
- allow up to 1800 characters in front-page highlight summary
- enlarge homepage highlight image placeholder to 700px height

## Testing
- `php -l wp-jornal.php`


------
https://chatgpt.com/codex/tasks/task_e_688ba1052448832cbaa487d697112658