### PR TITLE
Remove colchetes do Divi

### DIFF
--- a/wp-jornal.php
+++ b/wp-jornal.php
@@ -172,11 +172,12 @@ function wpj_list_jornais()
 }
 
 /**
- * Remove shortcodes do Divi e tags HTML.
+ * Remove shortcodes do Divi, trechos entre colchetes e tags HTML.
  */
 function wpj_clean_text($text)
 {
     $text = strip_shortcodes($text);
+    $text = preg_replace('/\[[^\]]*\]/', '', $text);
     $text = wp_strip_all_tags($text);
     $text = preg_replace('/\s+/u', ' ', $text);
     return trim($text);


### PR DESCRIPTION
## Summary
- Remove trecho entre colchetes gerados por Divi antes da limpeza de tags

## Testing
- `php -l wp-jornal.php`
- `php -r '$text="[et_pb_section fb_built=\"1\"][et_pb_text]A USE"; $text=preg_replace("/\[[^\]]*\]/","",$text); echo $text, "\n";''`


------
https://chatgpt.com/codex/tasks/task_e_688ba2958878832c8c2b8c992825f460