### PR TITLE
feat: add anchors and extra article selection

### DIFF
--- a/modelo/capa.html
+++ b/modelo/capa.html
@@ -5,7 +5,7 @@
     <h1 class="main-title">O MENSAGEIRO</h1>
 
     <div class="section">
-        <h2 class="section-title">__destaque_titulo__</h2>
+        <h2 class="section-title"><a href="#__destaque_anchor__">__destaque_titulo__</a></h2>
         <p class="date">__destaque_data__</p>
         <div class="columns with-image">
             <div class="text">
@@ -24,7 +24,7 @@
     <div class="section with-background">
         <div class="columns" style="border-bottom: 0px">
             <div class="text">
-                <h2 class="section-title small">__post_1_titulo__</h2>
+                <h2 class="section-title small"><a href="#__post_1_anchor__">__post_1_titulo__</a></h2>
                 <p class="date">__post_1_data__</p>
                 <p>__post_1_chamada__</p>
             </div>
@@ -33,15 +33,16 @@
 
     <div class="columns three">
         <div>
-            <h3 class="small-title">__post_2_titulo__</h3>
+            <h3 class="small-title"><a href="#__post_2_anchor__">__post_2_titulo__</a></h3>
             <p>__post_2_chamada__</p>
         </div>
         <div>
-            <h3 class="small-title">__post_3_titulo__</h3>
+            <h3 class="small-title"><a href="#__post_3_anchor__">__post_3_titulo__</a></h3>
             <p>__post_3_chamada__</p>
         </div>
         <div>
-            <h3 class="small-title">__post_4_titulo__</h3>
-            <p>__post_4_chamada__</p>    </div>
+            <h3 class="small-title"><a href="#__post_4_anchor__">__post_4_titulo__</a></h3>
+            <p>__post_4_chamada__</p>
+        </div>
     </div>
 </div>

--- a/modelo/materia-full.html
+++ b/modelo/materia-full.html
@@ -1,6 +1,6 @@
 
 <!-- MATÉRIA full -->
-<div class="page" id="pagina-3">
+<div class="page">
 
 
     <div class="columns">

--- a/modelo/materia.html
+++ b/modelo/materia.html
@@ -1,6 +1,6 @@
 
 <!-- MATÉRIA 1 -->
-<div class="page" id="pagina-2">
+<div class="page" id="__post_anchor__">
 
     <h2 class="section-title">__post_1_titulo__</h2>
     <p class="date">__post_1_data__</p>


### PR DESCRIPTION
## Summary
- link cover items directly to their full articles via anchors
- add third step to choose unlimited additional articles and exclude already selected posts
- update article generation to include anchors and extra posts

## Testing
- `php -l wp-jornal.php`


------
https://chatgpt.com/codex/tasks/task_e_688bab60b878832c9e17df0faa436011