### PR TITLE
Corrige repetição de conteúdo em matérias longas

### DIFF
--- a/modelo/materia-6000.html
+++ b/modelo/materia-6000.html
@@ -1,6 +1,6 @@
-<!-- MATÉRIA 4000 -->
+<!-- MATÉRIA 6000 -->
 
-<div class="page" id="materia-4000">
+<div class="page" id="materia-6000">
 
     <h2 class="section-title">A Luta de Cada Um - Lea C. Micelli</h2>
     <p class="date">31/10/2024</p>
@@ -9,7 +9,7 @@
         <div>
             <p>__post_1_conteudo_600__</p>
         </div>        <div>
-        <div class="image-placeholder  img-materia-4000" style="
+        <div class="image-placeholder  img-materia-6000" style="
     height: 400px;
     width: 460px;
     background-size: cover;
@@ -67,15 +67,15 @@
     <div class="columns">
 
         <div>
-            <p>__post_6_conteudo_600__</p>
-        </div>
-
-        <div>
-            <p>__post_7_conteudo_600__</p>
-        </div>
-
-        <div>
             <p>__post_8_conteudo_600__</p>
+        </div>
+
+        <div>
+            <p>__post_9_conteudo_600__</p>
+        </div>
+
+        <div>
+            <p>__post_10_conteudo_600__</p>
         </div>
 
 

--- a/wp-jornal.php
+++ b/wp-jornal.php
@@ -412,7 +412,7 @@ function wpj_render_materia_html($post_id)
             $parts[2] ?? '',
         ]);
         return str_replace($search, $replace, $template);
-    } elseif ($len <= 60000) {
+    } elseif ($len <= 6000) {
         $template = file_get_contents($template_dir . 'materia-6000.html');
         $template = preg_replace('/<div class="page"[^>]*>/', '<div class="page" id="__post_anchor__">', $template, 1);
         list($p1, $resto) = wpj_cut_text($texto, 600);
@@ -456,7 +456,7 @@ function wpj_render_materia_html($post_id)
 
 /**
  * Renderiza a matéria utilizando o layout padrão com páginas extras.
- * Mantido como fallback para textos maiores que 4000 caracteres.
+ * Mantido como fallback para textos maiores que 6000 caracteres.
  */
 function wpj_render_large_materia($p, $img, $texto, $base_search, $base_replace)
 {


### PR DESCRIPTION
## Summary
- Corrige o limite de seleção do layout para textos de até 6000 caracteres
- Atualiza o template `materia-6000` para conter todos os placeholders sem repetição

## Testing
- `php -l wp-jornal.php`
- `php -l modelo/materia-6000.html`


------
https://chatgpt.com/codex/tasks/task_e_688bca8b341c832c91e0a5dd8d152c42