### PR TITLE
Add mobile layout option for WP Jornal

### DIFF
--- a/modelo/capa-mobile.html
+++ b/modelo/capa-mobile.html
@@ -1,0 +1,15 @@
+<!-- CAPA MOBILE -->
+<div class="page capa">
+  <h1 class="main-title">O MENSAGEIRO</h1>
+  <h2 class="section-title"><a href="#__destaque_anchor__">__destaque_titulo__</a></h2>
+  <p class="date">__destaque_data__</p>
+  <a href="#__destaque_anchor__"><div class="image-placeholder" style="background-image: url(__destaque_imagem_url__);"></div></a>
+  <div class="legenda">__destaque_imagem_legenda__</div>
+  <p><a href="#__destaque_anchor__">__destaque_chamada__</a></p>
+  <ul class="lista-materias">
+    <li><a href="#__post_1_anchor__"><strong>__post_1_titulo__</strong> - __post_1_chamada__</a></li>
+    <li><a href="#__post_2_anchor__"><strong>__post_2_titulo__</strong> - __post_2_chamada__</a></li>
+    <li><a href="#__post_3_anchor__"><strong>__post_3_titulo__</strong> - __post_3_chamada__</a></li>
+    <li><a href="#__post_4_anchor__"><strong>__post_4_titulo__</strong> - __post_4_chamada__</a></li>
+  </ul>
+</div>

--- a/modelo/html-completo-mobile.html
+++ b/modelo/html-completo-mobile.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jornal O Mensageiro - __data__</title>
+  <style>
+    body{font-family:Arial, sans-serif;margin:0;padding:0;background:#fff;}
+    .page{padding:20px;border-bottom:1px solid #ccc;max-width:600px;margin:0 auto;}
+    .main-title{text-align:center;font-size:32px;margin:10px 0;font-weight:bold;}
+    .section-title{font-size:24px;margin:10px 0;font-weight:bold;}
+    .date{font-size:14px;color:#666;margin-bottom:10px;}
+    .image-placeholder{width:100%;background:#eee;background-size:cover;background-position:center;padding-bottom:56%;margin-bottom:10px;}
+    .lista-materias{list-style:none;padding:0;}
+    .lista-materias li{margin:10px 0;}
+    .lista-materias a{text-decoration:none;color:#000;}
+    .legenda{text-align:center;font-size:12px;color:#555;margin-bottom:10px;}
+    .conteudo p{margin-bottom:15px;}
+  </style>
+</head>
+<body>
+__body__
+</body>
+</html>

--- a/modelo/materia-mobile.html
+++ b/modelo/materia-mobile.html
@@ -1,0 +1,8 @@
+<!-- MATÉRIA MOBILE -->
+<div class="page" id="__post_anchor__">
+  <h2 class="section-title">__post_titulo__</h2>
+  <p class="date">__post_data__</p>
+  <div class="image-placeholder" style="background-image: url(__post_imagem_url__);"></div>
+  <div class="legenda">__post_imagem_legenda__</div>
+  <div class="conteudo">__post_conteudo__</div>
+</div>


### PR DESCRIPTION
## Summary
- allow choosing normal or mobile layout before generating
- support mobile rendering via new templates and article renderer

## Testing
- `php -l wp-jornal.php`


------
https://chatgpt.com/codex/tasks/task_e_688bd78a8314832cb931e357934f00e1